### PR TITLE
Avoid duplicate modules

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -211,4 +211,11 @@ BCp.getProvidedP = util.cachedMethod(function() {
     });
 });
 
+var providesExp = /@providesModule[ ]+(\S+)/;
+
+BCp.getProvidedId = function(source) {
+    var match = providesExp.exec(source);
+    return match && match[1];
+};
+
 exports.BuildContext = BuildContext;

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -9,7 +9,7 @@ var BuildContext = require("./context").BuildContext;
 var DiskCache = require("./cache").DiskCache;
 var slice = Array.prototype.slice;
 
-function ModuleReader(context, resolvers, processors, wrapper) {
+function ModuleReader(context, resolvers, processors) {
     var self = this;
     assert.ok(self instanceof ModuleReader);
     assert.ok(context instanceof BuildContext);

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -40,6 +40,7 @@ function ModuleReader(context, resolvers, processors) {
 
     Object.defineProperties(self, {
         context: { value: context },
+        idToHash: { value: {} },
         resolvers: { value: resolvers },
         processors: { value: processors },
         salt: { value: hash.digest("hex") },
@@ -82,15 +83,34 @@ ModuleReader.prototype = {
     readModuleP: util.cachedMethod(function(id) {
         var reader = this;
 
-        var hash = createHash("sha1")
-            .update("module\0")
-            .update(id + "\0")
-            .update(reader.salt + "\0");
-
         return reader.getSourceP(id).then(function(source) {
+            // If the source contains a @providesModule declaration, treat
+            // that declaration as canonical. Note that the Module object
+            // returned by readModuleP might have an .id property whose
+            // value differs from the original id parameter.
+            id = reader.context.getProvidedId(source) || id;
+
             assert.strictEqual(typeof source, "string");
-            hash.update(source.length + "\0" + source);
-            return reader.buildModuleP(id, hash.digest("hex"), source);
+
+            var hash = createHash("sha1")
+                .update("module\0")
+                .update(id + "\0")
+                .update(reader.salt + "\0")
+                .update(source.length + "\0" + source)
+                .digest("hex");
+
+            if (reader.idToHash.hasOwnProperty(id)) {
+                // Ensure that the same module identifier is not
+                // provided by distinct modules.
+                assert.strictEqual(
+                    reader.idToHash[id], hash,
+                    "more than one module named " +
+                        JSON.stringify(id));
+            } else {
+                reader.idToHash[id] = hash;
+            }
+
+            return reader.buildModuleP(id, hash, source);
         });
     }),
 
@@ -120,6 +140,9 @@ ModuleReader.prototype = {
 
     readMultiP: function(ids) {
         var reader = this;
+
+        // TODO Remove duplicates.
+
         return Q.all(ids).then(function(ids) {
             return Q.all(ids.map(reader.readModuleP, reader));
         });

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -141,10 +141,24 @@ ModuleReader.prototype = {
     readMultiP: function(ids) {
         var reader = this;
 
-        // TODO Remove duplicates.
-
         return Q.all(ids).then(function(ids) {
-            return Q.all(ids.map(reader.readModuleP, reader));
+            if (ids.length === 0)
+                return ids; // Shortcut.
+
+            var modulePs = ids.map(reader.readModuleP, reader);
+            return Q.all(modulePs).then(function(modules) {
+                var seen = {};
+                var result = [];
+
+                modules.forEach(function(module) {
+                    if (!seen.hasOwnProperty(module.id)) {
+                        seen[module.id] = true;
+                        result.push(module);
+                    }
+                });
+
+                return result;
+            });
         });
     }
 };

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -164,6 +164,6 @@ Module.prototype = {
     },
 
     resolveId: function(id) {
-        return path.normalize(path.join(this.id, "..", id));
+        return util.absolutize(this.id, id);
     }
 };

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -35,7 +35,7 @@ function ModuleReader(context, resolvers, processors) {
 
     var procArgs = [processors];
     if (!context.ignoreDependencies)
-        procArgs.push(require("./relative").relativizeP);
+        procArgs.push(require("./relative").getProcessor(self));
     processors = hashCallbacks("processors", procArgs);
 
     Object.defineProperties(self, {

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -48,7 +48,7 @@ function ModuleReader(context, resolvers, processors) {
 }
 
 ModuleReader.prototype = {
-    getSourceP: function(id) {
+    getSourceP: util.cachedMethod(function(id) {
         var context = this.context;
         var copy = this.resolvers.slice(0).reverse();
         assert.ok(copy.length > 0, "no source resolvers registered");
@@ -70,7 +70,14 @@ ModuleReader.prototype = {
         }
 
         return tryNextResolverP();
-    },
+    }),
+
+    getCanonicalIdP: util.cachedMethod(function(id) {
+        var reader = this;
+        return reader.getSourceP(id).then(function(source) {
+            return reader.context.getProvidedId(source) || id;
+        });
+    }),
 
     readModuleP: util.cachedMethod(function(id) {
         var reader = this;

--- a/lib/relative.js
+++ b/lib/relative.js
@@ -1,24 +1,81 @@
 var assert = require("assert");
+var Q = require("q");
 var path = require("path");
-var makePromise = require("./util").makePromise;
+var util = require("./util");
 var recast = require("recast");
 var n = recast.namedTypes;
 
-exports.relativizeP = function(id, source) {
-    return makePromise(function(callback) {
-        recast.runString(source, function(ast, callback) {
-            callback(new RequireVisitor(id).visit(ast));
+function Relativizer(reader) {
+    assert.ok(this instanceof Relativizer);
+    assert.ok(reader === null ||
+              reader instanceof require("./reader").ModuleReader);
+
+    Object.defineProperties(this, {
+        reader: { value: reader }
+    });
+}
+
+var Rp = Relativizer.prototype;
+
+exports.getProcessor = function(reader) {
+    var relativizer = new Relativizer(reader);
+    return function(id, source) {
+        return relativizer.processSourceP(id, source);
+    };
+};
+
+Rp.processSourceP = function(id, source) {
+    var visitor = new RequireVisitor(this, id);
+
+    return util.makePromise(function(finish) {
+        recast.runString(source, function(ast, reprint) {
+            ast = visitor.visit(ast);
+            Q.all(visitor.promises).then(function() {
+                reprint(ast);
+            });
         }, {
             writeback: function(code) {
-                callback(null, code);
+                finish(null, code);
             }
         });
     });
 };
 
+Rp.absolutizeP = function(moduleId, requiredId) {
+    requiredId = util.absolutize(moduleId, requiredId);
+
+    if (this.reader)
+        return this.reader.getCanonicalIdP(requiredId);
+
+    return Q.resolve(requiredId);
+};
+
+Rp.relativizeP = function(moduleId, requiredId) {
+    return this.absolutizeP(
+        moduleId,
+        requiredId
+    ).then(function(absoluteId) {
+        return util.relativize(moduleId, absoluteId);
+    });
+};
+
 var RequireVisitor = recast.Visitor.extend({
-    init: function(moduleId) {
+    init: function(relativizer, moduleId) {
+        assert.ok(relativizer instanceof Relativizer);
+        this.relativizer = relativizer;
         this.moduleId = moduleId;
+        this.promises = [];
+    },
+
+    fixRequireP: function(literal) {
+        var promise = this.relativizer.relativizeP(
+            this.moduleId,
+            literal.value
+        ).then(function(newValue) {
+            return literal.value = newValue;
+        });
+
+        this.promises.push(promise);
     },
 
     visitCallExpression: function(exp) {
@@ -31,7 +88,7 @@ var RequireVisitor = recast.Visitor.extend({
             if (n.Literal.check(arg) &&
                 typeof arg.value === "string")
             {
-                arg.value = relativize(this.moduleId, arg.value);
+                this.fixRequireP(arg);
                 return;
             }
         }
@@ -39,21 +96,3 @@ var RequireVisitor = recast.Visitor.extend({
         this.genericVisit(exp);
     }
 });
-
-function relativize(moduleId, requiredId) {
-    if (requiredId.charAt(0) === ".") {
-        // Keep the required ID relative.
-    } else {
-        // Relativize the required ID.
-        requiredId = path.relative(
-            path.join(moduleId, ".."),
-            requiredId
-        );
-    }
-
-    requiredId = path.normalize(requiredId);
-    if (requiredId.charAt(0) !== ".")
-        requiredId = "./" + requiredId;
-
-    return requiredId;
-}

--- a/lib/util.js
+++ b/lib/util.js
@@ -295,3 +295,30 @@ exports.inherits = function(ctor, base) {
         constructor: { value: ctor }
     });
 };
+
+function absolutize(moduleId, requiredId) {
+    if (requiredId.charAt(0) === ".")
+        requiredId = path.join(moduleId, "..", requiredId);
+    return path.normalize(requiredId);
+}
+exports.absolutize = absolutize;
+
+function relativize(moduleId, requiredId) {
+    requiredId = absolutize(moduleId, requiredId);
+
+    if (requiredId.charAt(0) === ".") {
+        // Keep the required ID relative.
+    } else {
+        // Relativize the required ID.
+        requiredId = path.relative(
+            path.join(moduleId, ".."),
+            requiredId
+        );
+    }
+
+    if (requiredId.charAt(0) !== ".")
+        requiredId = "./" + requiredId;
+
+    return requiredId;
+}
+exports.relativize = relativize;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "browserify",
     "stitch"
   ],
-  "version": "0.6.5",
+  "version": "0.6.6",
   "homepage": "http://github.com/benjamn/commoner",
   "repository": {
     "type": "git",

--- a/test/run.js
+++ b/test/run.js
@@ -168,13 +168,21 @@ exports.testProvidesModule = function(t, assert) {
         ], []);
 
         return Q.all([
-            reader.readMultiP([
-                "widget/share",
-                "WidgetShare"
+            Q.all([
+                reader.readModuleP("widget/share"),
+                reader.readModuleP("WidgetShare")
             ]).spread(function(ws1, ws2) {
                 assert.strictEqual(ws1.id, ws2.id);
                 assert.strictEqual(ws1.id, "WidgetShare");
                 assert.strictEqual(ws1, ws2);
+            }),
+
+            reader.readMultiP([
+                "widget/share",
+                "WidgetShare"
+            ]).then(function(modules) {
+                assert.strictEqual(modules.length, 1);
+                assert.strictEqual(modules[0].id, "WidgetShare");
             }),
 
             Q.all([

--- a/test/run.js
+++ b/test/run.js
@@ -217,7 +217,7 @@ exports.testMakePromise = function(t, assert) {
 
 exports.testRelativize = function(t, assert) {
     var moduleId = "some/deeply/nested/module";
-    var relativizeP = require("../lib/relative").relativizeP;
+    var processor = require("../lib/relative").getProcessor(null);
 
     function makeSource(id) {
         var str = JSON.stringify(id);

--- a/test/run.js
+++ b/test/run.js
@@ -153,6 +153,7 @@ exports.testMakePromise = function(t, assert) {
 };
 
 exports.testRelativize = function(t, assert) {
+    var moduleId = "some/deeply/nested/module";
     var relativizeP = require("../lib/relative").relativizeP;
 
     function makeSource(id) {
@@ -162,8 +163,12 @@ exports.testRelativize = function(t, assert) {
     }
 
     function helperP(requiredId, expected) {
-        return relativizeP(
-            "some/deeply/nested/module",
+        assert.strictEqual(
+            util.relativize(moduleId, requiredId),
+            expected);
+
+        return processor(
+            moduleId,
             makeSource(requiredId)
         ).then(function(source) {
             assert.strictEqual(source, makeSource(expected));

--- a/test/run.js
+++ b/test/run.js
@@ -185,6 +185,15 @@ exports.testProvidesModule = function(t, assert) {
                 assert.strictEqual(modules[0].id, "WidgetShare");
             }),
 
+            reader.readModuleP(
+                "widget/gallery"
+            ).then(function(gallery) {
+                return gallery.getRequiredP();
+            }).then(function(deps) {
+                assert.strictEqual(deps.length, 1);
+                assert.strictEqual(deps[0].id, "WidgetShare");
+            }),
+
             Q.all([
                 reader.getSourceP("widget/share"),
                 reader.getSourceP("WidgetShare")

--- a/test/source/widget/follow.js
+++ b/test/source/widget/follow.js
@@ -1,1 +1,20 @@
+// All these ways of requiring WidgetShare should get normalized to the
+// same relative identifier: "../WidgetShare".
+require("./share");
+require("../widget/share");
+require("WidgetShare");
+require("../WidgetShare");
+
+// These identifiers will both become "./gallery".
+require("../widget/gallery");
+require("./gallery");
+
+// These both become "../assert".
+require("assert");
+require("../assert");
+
+// These circular references should both become "./follow".
+require("./follow");
+require("../widget/follow");
+
 exports.name = "widget/follow";

--- a/test/source/widget/gallery.js
+++ b/test/source/widget/gallery.js
@@ -1,1 +1,5 @@
+require("../widget/share");
+require("./share");
+require("WidgetShare");
+
 exports.name = "widget/gallery";

--- a/wrappers/amd.js
+++ b/wrappers/amd.js
@@ -1,5 +1,0 @@
-module.exports = function(id, source) {
-    return "define(" + JSON.stringify(id) +
-        ",function(require,exports,module){" +
-        source + "});";
-};

--- a/wrappers/install.js
+++ b/wrappers/install.js
@@ -1,5 +1,0 @@
-module.exports = function(id, source) {
-    return "install(" + JSON.stringify(id) +
-        ",function(require,exports,module){" +
-        source + "});";
-};

--- a/wrappers/naked.js
+++ b/wrappers/naked.js
@@ -1,3 +1,0 @@
-module.exports = function(id, source) {
-    return source;
-};


### PR DESCRIPTION
The meat of this change is that we now prefer the identifier declared by `@providesModule`, if any, to the original identifier that was to be resolved.

Relative identifiers required by a module that contains a `@providesModule` directive will be evaluated relative to the provided identifier.
