### PR TITLE
Tell grep to treat binary files as text

### DIFF
--- a/lib/watcher.js
+++ b/lib/watcher.js
@@ -286,6 +286,7 @@ function grepP(pattern, grepExtension) {
     var grep = run("grep", [
         "--recursive",
         "--only-matching",
+        "--text", // treat binary files (e.g., vim swp) as text
         "--null", // separate file from match with \0 instead of :
         grepExtension,
         pattern,


### PR DESCRIPTION
Without this, grep will output something like 'Binary file react/src/.DOMPropertyOperations.swp matches' instead of the actual match, which subsequently makes the code in BuildContext.prototype.getProvidedP unhappy since it doesn't see the real filename and there's no match for it to look at.

Adding the `--text` flag makes grep behave the same on binary files, which is ideal since we're not printing the intermediary output to a terminal anyway.

(Now I can actually build React while I have vim open!)
