### PR TITLE
Run initial grep test lazily

### DIFF
--- a/lib/grep.js
+++ b/lib/grep.js
@@ -12,21 +12,26 @@ function run(cmd, args) {
     });
 }
 
-var grepExtensionDef = Q.defer();
-var grepExtensionP = grepExtensionDef.promise;
-
-run("grep", [
-    "--quiet",
-    "--perl-regexp",
-    "spawn",
-    __filename
-]).on("close", function(code) {
-    if (code === 0 || code === 1) {
-        grepExtensionDef.resolve("--perl-regexp");
-    } else {
-        grepExtensionDef.resolve("--extended-regexp");
+var _grepExtensionP;
+function grepExtensionP() {
+    if (!_grepExtensionP) {
+        var grepExtensionDef = Q.defer();
+        run("grep", [
+            "--quiet",
+            "--perl-regexp",
+            "spawn",
+            __filename
+        ]).on("close", function(code) {
+            if (code === 0 || code === 1) {
+                grepExtensionDef.resolve("--perl-regexp");
+            } else {
+                grepExtensionDef.resolve("--extended-regexp");
+            }
+        });
+        _grepExtensionP = grepExtensionDef.promise;
     }
-});
+    return _grepExtensionP;
+}
 
 function grepP(pattern, sourceDir, grepExtension) {
     var grep = run("grep", [
@@ -94,7 +99,7 @@ function grepP(pattern, sourceDir, grepExtension) {
 };
 
 module.exports = function(pattern, sourceDir) {
-    return grepExtensionP.then(function(extension) {
+    return grepExtensionP().then(function(extension) {
         return grepP(pattern, sourceDir, extension);
     });
 };


### PR DESCRIPTION
On Windows, grep doesn't exist. This patch allows the use of commoner-based transformers that don't use module path relativization when grep isn't available.

Fixes facebook/react#316, facebook/react#391, facebook/react#567.
