### PR TITLE
Add support for files with whitespace in name

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -302,7 +302,7 @@ exports.idToSlug = function(id) {
     return id.replace(slugExp, "_");
 };
 
-var moduleIdExp = /^[a-z0-9\-_\/\.]+$/i;
+var moduleIdExp = /^[ a-z0-9\-_\/\.]+$/i;
 exports.isValidModuleId = function(id) {
     return id === "<stdin>" || moduleIdExp.test(id);
 };


### PR DESCRIPTION
When running commoner on files with whitespaces within them (tried on jsx tool), it silently doesn't process such files. 
If this pull request isn't merged (you may have some concerns on whitespaced names), I suggest adding warning about not processing filenames with whitespaces.
