### PR TITLE
Fix mkdirP ternary to work with no outputDir

### DIFF
--- a/lib/commoner.js
+++ b/lib/commoner.js
@@ -145,7 +145,7 @@ Cp.buildP = function(options, roots) {
 
     return (
       // If outputDir is falsy, we can't (and don't need to) mkdirP it.
-      outputDir ? Q.resolve : util.mkdirP
+      outputDir ? util.mkdirP : Q.resolve
     )(outputDir).then(rebuild);
 };
 


### PR DESCRIPTION
As the comment says, we don't want to call mkdirP(null); the logic here was reversed. The old code worked before because mkdirP(manifestDir) was executed before anything was written, but this code is what was originally intended.

@benjamn Mind merging and publishing a new version on npm?

cc @zpao
