### PR TITLE
Add support for alternative charsets

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -11,9 +11,11 @@ var hasOwn = Object.prototype.hasOwnProperty;
  * memory so that subsequent calls to readFileP return the same contents,
  * regardless of any changes in the underlying file.
  */
-function ReadFileCache(sourceDir) {
+function ReadFileCache(sourceDir, charset) {
     assert.ok(this instanceof ReadFileCache);
     assert.strictEqual(typeof sourceDir, "string");
+
+    this.charset = charset;
 
     EventEmitter.call(this);
 
@@ -50,7 +52,7 @@ RFCp.noCacheReadFileP = function(relativePath) {
 
     var added = !hasOwn.call(this.sourceCache, relativePath);
     var promise = this.sourceCache[relativePath] = util.readFileP(
-        path.join(this.sourceDir, relativePath));
+        path.join(this.sourceDir, relativePath), this.charset);
 
     if (added) {
         this.emit("added", relativePath);

--- a/lib/commoner.js
+++ b/lib/commoner.js
@@ -72,7 +72,7 @@ Cp.buildP = function(options, roots) {
     var self = this;
     var sourceDir = options.sourceDir;
     var outputDir = options.outputDir;
-    var readFileCache = new ReadFileCache(sourceDir);
+    var readFileCache = new ReadFileCache(sourceDir, options.charsetInput);
     var waiting = 0;
     var output = outputDir
         ? new DirOutput(outputDir)
@@ -210,7 +210,10 @@ function cliBuildP(commoner, version) {
         .option("--relativize", "Rewrite all module identifiers to be relative")
         .option("--follow-requires", "Scan modules for required dependencies")
         .option("--cache-dir <directory>", "Alternate directory to use for disk cache")
-        .option("--no-cache-dir", "Disable the disk cache");
+        .option("--no-cache-dir", "Disable the disk cache")
+        .option("--test", "Disable the disk cache")
+        .option("--charset-input <utf8 | win1252 | ...>", "Charset of input (deafult 'utf8')")
+        .option("--charset-output <utf8 | win1252 | ...>", "Charset of output (deafult 'utf8')");
 
     commoner.customOptions.forEach(function(customOption) {
         options.option.apply(options, customOption);
@@ -226,6 +229,7 @@ function cliBuildP(commoner, version) {
     commoner.watch = options.watch;
     commoner.ignoreDependencies = !options.followRequires;
     commoner.relativize = options.relativize;
+    commoner.charsetInput = options.charsetInput; 
 
     function fileToId(file) {
         file = absolutePath(workingDir, file);
@@ -259,7 +263,7 @@ function cliBuildP(commoner, version) {
             sourceDir = workingDir;
             outputDir = null;
             roots = [firstId];
-            commoner.forceResolve(firstId, util.readFileP(first));
+            commoner.forceResolve(firstId, util.readFileP(first, commoner.charsetInput));
 
             // Ignore dependencies because we wouldn't know how to find them.
             commoner.ignoreDependencies = true;
@@ -304,6 +308,7 @@ function cliBuildP(commoner, version) {
         cleanOptions.config = config;
         cleanOptions.sourceDir = sourceDir;
         cleanOptions.outputDir = outputDir;
+        cleanOptions.charsetInput = commoner.charsetInput;
 
         return commoner.buildP(cleanOptions, roots);
     });

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -2,6 +2,7 @@ var assert = require("assert");
 var path = require("path");
 var fs = require("fs");
 var Q = require("q");
+var iconv = require("iconv-lite");
 var createHash = require("crypto").createHash;
 var getRequiredIDs = require("install").getRequiredIDs;
 var util = require("./util");
@@ -127,6 +128,7 @@ ModuleReader.prototype = {
         var reader = this;
         var cacheDir = reader.context.cacheDir;
         var manifestDir = cacheDir && path.join(cacheDir, "manifest");
+        var charset = reader.context.options.charsetOutput;
 
         function buildP() {
             var promise = Q(source);
@@ -182,7 +184,12 @@ ModuleReader.prototype = {
                         Object.keys(output).forEach(function(key) {
                             var cacheFile = manifest[key] = hash + key;
                             var fullPath = path.join(cacheDir, cacheFile);
-                            fs.writeFileSync(fullPath, output[key], "utf8");
+
+                            if(charset) {
+                                fs.writeFileSync(fullPath, iconv.encode(output[key], charset))
+                            } else {
+                                fs.writeFileSync(fullPath, output[key], "utf8");
+                            }
                         });
 
                         fs.writeFileSync(
@@ -268,12 +275,17 @@ Module.prototype = {
         var hash = this.hash;
         var output = this.output;
         var cacheDir = this.reader.context.cacheDir;
+        var charset = this.reader.context.options.charsetOutput;
 
         return Q.all(Object.keys(output).map(function(key) {
             var outputFile = path.join(outputDir, id + key);
 
             function writeCopy() {
-                fs.writeFileSync(outputFile, output[key], "utf8");
+                if(charset) {
+                    fs.writeFileSync(outputFile, output[key], "utf8");
+                } else {
+                    fs.writeFileSync(outputFile, iconv.encode(output[key], charset))
+                }
                 return outputFile;
             }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,6 +4,7 @@ var fs = require("graceful-fs");
 var Q = require("q");
 var createHash = require("crypto").createHash;
 var mkdirp = require("mkdirp");
+var iconv = require("iconv-lite");
 var Ap = Array.prototype;
 var slice = Ap.slice;
 var join = Ap.join;
@@ -57,9 +58,15 @@ exports.cachedMethod = function(fn, keyFn) {
     return wrapper;
 };
 
-function readFileP(file) {
+function readFileP(file, charset) {
     return makePromise(function(callback) {
-        return fs.readFile(file, "utf8", callback);
+        if(!charset || charset === "utf8") return fs.readFile(file, "utf8", callback);
+
+        return fs.readFile(file, function (err, data) {
+            if(err) callback(err, data);
+
+            callback(err, iconv.decode(data, charset));
+        });
     });
 }
 exports.readFileP = readFileP;

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "glob": ">= 3.2.1",
     "mkdirp": ">= 0.3.5",
     "private": ">= 0.0.4",
-    "install": ">= 0.1.7"
+    "install": ">= 0.1.7",
+    "iconv-lite": "*"
   },
   "optionalDependencies": {
     "whiskey": "0.6.x"


### PR DESCRIPTION
Sometimes, neither source files nor output of JSX (ReactJS), or any other transformation, can be done from utf8 to utf8. In these scenarios, it's useful to be able to specify input and output charset. This PR adds support for this.
