### PR TITLE
Make whiskey a devDependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "install": "~0.1.7",
     "iconv-lite": "~0.2.11"
   },
-  "optionalDependencies": {
+  "devDependencies": {
     "whiskey": "0.6.x"
   },
   "engines": {


### PR DESCRIPTION
`whiskey` should be in `devDependencies`. `optionalDependencies` are always installed (if possible, failure is non-fatal), while `devDependencies` are not installed when the module is itself installed as a dependency. This is standard practice for test-runners.

If this is accepted, I'd like the same change in https://github.com/benjamn/install, making whiskey not get installed (twice!) with react-tools.
