### PR TITLE
Fix npm test on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "commonize": "./bin/commonize"
   },
   "scripts": {
-    "test": "whiskey test/run.js"
+    "test": "node test/run-tests.js"
   },
   "dependencies": {
     "q": "~1.0.1",

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -1,0 +1,9 @@
+var whiskey = require("whiskey");
+
+var args = ['node', 'whiskey', '--tests', 'test/run.js'];
+
+if (process.platform === 'win32') {
+    args.push('--socket-path', '\\\\.\\pipe\\whiskey-'+(Math.random() * 10000));
+}
+
+whiskey.run(process.cwd(), args);


### PR DESCRIPTION
whiskey uses a unix domain socket by default. Change to use a named pipe
on Windows.
