### PR TITLE
Make the grep module cross platform

### DIFF
--- a/lib/grep.js
+++ b/lib/grep.js
@@ -1,105 +1,46 @@
-var assert = require("assert");
-var path = require("path");
-var spawn = require("child_process").spawn;
+var path = require('path');
 var Q = require("q");
-var util = require("./util");
-var hasOwn = Object.prototype.hasOwnProperty;
+var fs = require('graceful-fs');
+var readdir = Q.denodeify(fs.readdir);
+var lstat = Q.denodeify(fs.lstat);
+var readFile = Q.denodeify(fs.readFile);
 
-function run(cmd, args) {
-    return spawn(cmd, args, {
-        stdio: "pipe",
-        env: process.env
+function processDirP(pattern, dir) {
+    return readdir(dir).then(function(files) {
+        return Q.all(files.map(function(file) {
+            file = path.join(dir, file);
+            return lstat(file).then(function(stat) {
+                return stat.isDirectory() ? processDirP(pattern, file) : processFileP(pattern, file);
+            })
+        })).then(function(results) {
+            return results.reduce(function(a, b) { return a.concat(b) }) // flatten the results
+        })
     });
 }
 
-var _grepExtensionP;
-function grepExtensionP() {
-    if (!_grepExtensionP) {
-        var grepExtensionDef = Q.defer();
-        run("grep", [
-            "--quiet",
-            "--perl-regexp",
-            "spawn",
-            __filename
-        ]).on("close", function(code) {
-            if (code === 0 || code === 1) {
-                grepExtensionDef.resolve("--perl-regexp");
-            } else {
-                grepExtensionDef.resolve("--extended-regexp");
-            }
-        });
-        _grepExtensionP = grepExtensionDef.promise;
-    }
-    return _grepExtensionP;
-}
-
-function grepP(pattern, sourceDir, grepExtension) {
-    var grep = run("grep", [
-        "--recursive",
-        "--only-matching",
-        "--text", // treat binary files (e.g., vim swp) as text
-        "--null", // separate file from match with \0 instead of :
-        grepExtension,
-        pattern,
-        sourceDir
-    ]);
-
-    var outs = [];
-    var errs = [];
-    var closed = false;
-
-    grep.stdout.on("data", function(data) {
-        assert.ok(!closed);
-        outs.push(data);
-    });
-
-    grep.stderr.on("data", function(data) {
-        assert.ok(!closed);
-        errs.push(data);
-    });
-
-    var deferred = Q.defer();
-    var promise = deferred.promise;
-
-    grep.on("close", function(code) {
-        assert.ok(!closed);
-        closed = true;
-
-        switch (code) {
-        default:
-            if (errs.length > 0) {
-                util.log.err(errs.join(""));
-            }
-
-            // intentionally fall through
-
-        case 0: case 1: // 1 means no results
-            deferred.resolve(outs.join(""));
+function processFileP(pattern, file) {
+    return readFile(file).then(function(contents) {
+        var result;
+        pattern = new RegExp(pattern, 'g');
+        if (result = pattern.exec(contents)) {
+            return [{
+                path: file,
+                match: result[0]
+            }]
         }
+        return [];
     });
-
-    return promise.then(function(out) {
-        var pathToMatch = {};
-
-        out.split("\n").forEach(function(line) {
-            if ((line = line.trim())) {
-                var splat = line.split("\0"); // see --null above
-                var relPath = path.relative(sourceDir, splat.shift());
-
-                // Only record the first match in any particular file.
-                if (hasOwn.call(pathToMatch, relPath))
-                    return;
-
-                pathToMatch[relPath] = splat.join("\0");
-            }
-        });
-
-        return pathToMatch;
-    });
-};
+}
 
 module.exports = function(pattern, sourceDir) {
-    return grepExtensionP().then(function(extension) {
-        return grepP(pattern, sourceDir, extension);
+    return processDirP(pattern, sourceDir).then(function(results) {
+        var pathToMatch = {};
+
+        results.forEach(function(result) {
+            var relPath = path.relative(sourceDir, result.path).replace(/\\/g, '/');
+            pathToMatch[relPath] = result.match;
+        });
+        
+        return pathToMatch;
     });
 };


### PR DESCRIPTION
Change the grep module to do recursive file searching using node instead
of the grep executable.

Fixed #45
