### PR TITLE
Fix module ids when building on Windows

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -319,7 +319,7 @@ exports.inherits = function(ctor, base) {
 function absolutize(moduleId, requiredId) {
     if (requiredId.charAt(0) === ".")
         requiredId = path.join(moduleId, "..", requiredId);
-    return path.normalize(requiredId);
+    return path.normalize(requiredId).replace(/\\/g, '/');
 }
 exports.absolutize = absolutize;
 
@@ -339,7 +339,7 @@ function relativize(moduleId, requiredId) {
     if (requiredId.charAt(0) !== ".")
         requiredId = "./" + requiredId;
 
-    return requiredId;
+    return requiredId.replace(/\\/g, '/');
 }
 exports.relativize = relativize;
 


### PR DESCRIPTION
Since module ids are manipulated using the path module, sometimes
backslashes are introduced into module ids on Windows. Explicitly
replace all backslashes with forward.
