### PR TITLE
Fix commoner command line interface for Node < 0.11

### DIFF
--- a/lib/commoner.js
+++ b/lib/commoner.js
@@ -350,7 +350,8 @@ function absolutePath(workingDir, pathToJoin) {
     if (pathToJoin) {
         workingDir = path.normalize(workingDir);
         pathToJoin = path.normalize(pathToJoin);
-        if (!path.isAbsolute(pathToJoin)) {
+        // TODO: use path.isAbsolute when Node < 0.10 is unsupported
+        if (path.resolve(pathToJoin) !== pathToJoin) {
             pathToJoin = path.join(workingDir, pathToJoin);
         }
     }


### PR DESCRIPTION
path.isAbsolute doesn't exist yet

This was screwing up the React build process. Likely it would be screwing up the JSX executable too. Can we get this fixed and shipped ASAP so I can shrinkwrap with this?
