### PR TITLE
Make @providesModule handling opt-in

### DIFF
--- a/lib/commoner.js
+++ b/lib/commoner.js
@@ -123,6 +123,8 @@ Cp.buildP = function(options, roots) {
 
         context.setRelativize(self.relativize);
 
+        context.setUseProvidesModule(self.useProvidesModule);
+
         return new ModuleReader(
             context,
             self.resolvers,
@@ -210,6 +212,7 @@ function cliBuildP(commoner, version) {
                 "File extension to assume when resolving module identifiers")
         .option("--relativize", "Rewrite all module identifiers to be relative")
         .option("--follow-requires", "Scan modules for required dependencies")
+        .option("--use-provides-module", "Respect @providesModules pragma in files")
         .option("--cache-dir <directory>", "Alternate directory to use for disk cache")
         .option("--no-cache-dir", "Disable the disk cache")
         .option("--source-charset <utf8 | win1252 | ...>",
@@ -231,6 +234,7 @@ function cliBuildP(commoner, version) {
     commoner.watch = options.watch;
     commoner.ignoreDependencies = !options.followRequires;
     commoner.relativize = options.relativize;
+    commoner.useProvidesModule = options.useProvidesModule;
     commoner.sourceCharset = normalizeCharset(options.sourceCharset);
     commoner.outputCharset = normalizeCharset(options.outputCharset);
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -100,6 +100,15 @@ BCp.setRelativize = function(value) {
 // This default can be overridden by individual BuildContext instances.
 BCp.setRelativize(false);
 
+BCp.setUseProvidesModule = function(value) {
+    Object.defineProperty(this, "useProvidesModule", {
+        value: !!value
+    });
+};
+
+// This default can be overridden by individual BuildContext instances.
+BCp.setUseProvidesModule(false);
+
 BCp.setCacheDirectory = function(dir) {
     if (!dir) {
         // Disable the cache directory.

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -74,20 +74,26 @@ ModuleReader.prototype = {
 
     getCanonicalIdP: util.cachedMethod(function(id) {
         var reader = this;
-        return reader.getSourceP(id).then(function(source) {
-            return reader.context.getProvidedId(source) || id;
-        });
+        if (reader.context.useProvidesModule) {
+            return reader.getSourceP(id).then(function(source) {
+                return reader.context.getProvidedId(source) || id;
+            });
+        } else {
+          return Q(id);
+        }
     }),
 
     readModuleP: util.cachedMethod(function(id) {
         var reader = this;
 
         return reader.getSourceP(id).then(function(source) {
-            // If the source contains a @providesModule declaration, treat
-            // that declaration as canonical. Note that the Module object
-            // returned by readModuleP might have an .id property whose
-            // value differs from the original id parameter.
-            id = reader.context.getProvidedId(source) || id;
+            if (reader.context.useProvidesModule) {
+                // If the source contains a @providesModule declaration, treat
+                // that declaration as canonical. Note that the Module object
+                // returned by readModuleP might have an .id property whose
+                // value differs from the original id parameter.
+                id = reader.context.getProvidedId(source) || id;
+            }
 
             assert.strictEqual(typeof source, "string");
 


### PR DESCRIPTION
I was going through old React issues and found https://github.com/facebook/react/issues/1145, which was the impetus for this change.

This changes the current behavior from parsing `@providesModule` all the time and having it overrule anything, to making it opt-in. If we wanted to get really crazy we could pull this out and only do that parsing in React's jsx-internal.

React build still works (without the new option actually, I think that means there's more to do here) but the test case in the linked issue does the right thing now, and still does the broken thing when using `--use-relative-requires`
