### PR TITLE
Make sure output directory tree exists before copying output files.

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -304,7 +304,7 @@ Module.prototype = {
                     .catch(writeCopy);
             }
 
-            return writeCopy();
+            return util.mkdirP(path.dirname(outputFile)).then(writeCopy);
         }));
     },
 


### PR DESCRIPTION
When using a cache directory (the typical/default case), Commoner's output files are hard links into the cache directory, created by `util.linkP`, which always calls `util.mkdirP`. When there is no cache directory, we just write copies of the output files. Before this commit, we were not ensuring that the full tree of enclosing directories already existed in the `--no-cache-dir` case.

Fixes #67.
