### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "q": "~1.0.1",
     "recast": "~0.7.0",
     "commander": "~2.2.0",
-    "graceful-fs": "~2.0.3",
+    "graceful-fs": "*",
     "glob": "~3.2.9",
     "mkdirp": "~0.3.5",
     "private": "~0.1.2",


### PR DESCRIPTION
Allow any version of graceful-fs (so it can be `npm dedupe` by enclosing modules)

Because graceful-fs is inherited based on node's fs interface, it makes sense to allow for any version (defaulting to the latest) ... This will allow other modules that use this module to use newer versions.

ex: my project uses graceful-fs@^3.0.4 and won't dedupe the version in this module.
