### PR TITLE
adds ability to ignore ids based on specified patterns

### DIFF
--- a/lib/commoner.js
+++ b/lib/commoner.js
@@ -16,6 +16,7 @@ var util = require("./util");
 var log = util.log;
 var Ap = Array.prototype;
 var each = Ap.forEach;
+var Op = Object.prototype;
 
 // Better stack traces for promises.
 Q.longStackSupport = true;
@@ -27,6 +28,7 @@ function Commoner() {
     Object.defineProperties(self, {
         customVersion: { value: null, writable: true },
         customOptions: { value: [] },
+        ignorePatterns: { value: [] },
         resolvers: { value: [] },
         processors: { value: [] }
     });
@@ -66,6 +68,13 @@ Cp.process = function(processor) {
         this.processors.push(processor);
     }, this);
 
+    return this; // For chaining.
+};
+
+// Specify specific patterns that should be ignored and not processed
+Cp.ignorePattern = function(pattern) {
+    assert.strictEqual(Op.toString.call(pattern), "[object RegExp]");
+    this.ignorePatterns.push(pattern);
     return this; // For chaining.
 };
 
@@ -124,6 +133,8 @@ Cp.buildP = function(options, roots) {
         context.setRelativize(self.relativize);
 
         context.setUseProvidesModule(self.useProvidesModule);
+
+        context.setIgnorePatterns(self.ignorePatterns);
 
         return new ModuleReader(
             context,

--- a/lib/context.js
+++ b/lib/context.js
@@ -124,6 +124,15 @@ BCp.setCacheDirectory = function(dir) {
 // This default can be overridden by individual BuildContext instances.
 BCp.setCacheDirectory(null);
 
+BCp.setIgnorePatterns = function(patterns) {
+    Object.defineProperty(this, "ignorePatterns", {
+        value: patterns || []
+    });
+};
+
+// This default can be overridden by individual BuildContext instances.
+BCp.setIgnorePatterns([]);
+
 function PreferredFileExtension(ext) {
     assert.strictEqual(typeof ext, "string");
     assert.ok(this instanceof PreferredFileExtension);
@@ -177,7 +186,21 @@ BCp.expandIdsOrGlobsP = function(idsOrGlobs) {
             }
         });
 
-        return result;
+        var filteredResult = [];
+        result.forEach(function(id) {
+            var ignore = false;
+            for (var i = 0; i < context.ignorePatterns.length; i++) {
+                if (context.ignorePatterns[i].test(id)) {
+                    ignore = true;
+                    break;
+                }
+            }
+            if (!ignore) {
+                filteredResult.push(id);
+            }
+        });
+
+        return filteredResult;
     });
 };
 

--- a/main.js
+++ b/main.js
@@ -14,3 +14,4 @@ function defCallback(name) {
 defCallback("version");
 defCallback("resolve");
 defCallback("process");
+defCallback("ignorePattern");


### PR DESCRIPTION
I wanted to be able to easily have commoner ignore test files and not try to resolve them, I couldn't figure it out easily so I just added support to filter the ids after globing them. If there is a cleaner solution or this is already solved in some other way I'd be happy to just improve documentation or examples instead

Now I can just do this in my custom config to have it ignore test files

```
require('commoner')
  .ignorePattern(/.*\/__tests__\/.*/)
  .resolve(function(id) {
      return this.readModuleP(id);
  }).process(function(id, source) {
    return source;
  });
```
