### PR TITLE
Ignore specific module ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Options:
   -x, --extension <js | coffee | ...>      File extension to assume when resolving module identifiers
   --relativize                             Rewrite all module identifiers to be relative
   --follow-requires                        Scan modules for required dependencies
+  --ignore-dependencies                    Ignore modules defined as dependencies in package.json
   --cache-dir <directory>                  Alternate directory to use for disk cache
   --no-cache-dir                           Disable the disk cache
   --source-charset <utf8 | win1252 | ...>  Charset of source (default: utf8)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Options:
   --relativize                             Rewrite all module identifiers to be relative
   --follow-requires                        Scan modules for required dependencies
   --ignore-dependencies                    Ignore modules defined as dependencies in package.json
+  --ignore-node-core                       Ignore Node's core modules ('fs', 'events', etc.)
   --cache-dir <directory>                  Alternate directory to use for disk cache
   --no-cache-dir                           Disable the disk cache
   --source-charset <utf8 | win1252 | ...>  Charset of source (default: utf8)

--- a/lib/commoner.js
+++ b/lib/commoner.js
@@ -3,7 +3,6 @@ var path = require("path");
 var fs = require("fs");
 var Q = require("q");
 var iconv = require("iconv-lite");
-var findup = require('findup-sync');
 var ReadFileCache = require("./cache").ReadFileCache;
 var Watcher = require("./watcher").Watcher;
 var contextModule = require("./context");
@@ -138,8 +137,11 @@ Cp.buildP = function(options, roots) {
         context.setUseProvidesModule(self.useProvidesModule);
 
         if (self.ignoreDependencies) {
-            var dependencies = Object.keys(require(findup("package.json")).dependencies);
-            self.ignorePatterns.push(new RegExp("^(" + dependencies.join('|') + ")(\\/|$)"));
+            self.ignorePatterns.push(util.makeDepsIgnorePattern());
+        }
+
+        if (self.ignoreNodeCore) {
+            self.ignorePatterns.push(util.makeCoreIgnorePattern());
         }
 
         context.setIgnorePatterns(self.ignorePatterns);
@@ -232,6 +234,7 @@ function cliBuildP(commoner, version) {
         .option("--relativize", "Rewrite all module identifiers to be relative")
         .option("--follow-requires", "Scan modules for required dependencies")
         .option("--ignore-dependencies", "Ignore modules defined as dependencies in package.json")
+        .option("--ignore-node-core", "Ignore Node's core modules ('fs', 'events', etc.)")
         .option("--use-provides-module", "Respect @providesModules pragma in files")
         .option("--cache-dir <directory>", "Alternate directory to use for disk cache")
         .option("--no-cache-dir", "Disable the disk cache")
@@ -254,6 +257,7 @@ function cliBuildP(commoner, version) {
     commoner.watch = options.watch;
     commoner.followRequires = options.followRequires;
     commoner.ignoreDependencies = options.ignoreDependencies;
+    commoner.ignoreNodeCore = options.ignoreNodeCore;
     commoner.relativize = options.relativize;
     commoner.useProvidesModule = options.useProvidesModule;
     commoner.sourceCharset = normalizeCharset(options.sourceCharset);

--- a/lib/commoner.js
+++ b/lib/commoner.js
@@ -119,7 +119,7 @@ Cp.buildP = function(options, roots) {
 
         context.setCacheDirectory(self.cacheDir);
 
-        context.setIgnoreDependencies(self.ignoreDependencies);
+        context.setFollowRequires(self.followRequires);
 
         context.setRelativize(self.relativize);
 
@@ -130,7 +130,7 @@ Cp.buildP = function(options, roots) {
             self.resolvers,
             self.processors
         ).readMultiP(context.expandIdsOrGlobsP(roots))
-            .then(context.ignoreDependencies ? pass : collectDepsP)
+            .then(context.followRequires ? collectRequiresP : pass)
             .then(outputModules)
             .then(outputDir ? printModuleIds : pass)
             .then(finish, function(err) {
@@ -156,7 +156,7 @@ function pass(modules) {
     return modules;
 }
 
-function collectDepsP(rootModules) {
+function collectRequiresP(rootModules) {
     var modules = [];
     var seenIds = {};
 
@@ -232,7 +232,7 @@ function cliBuildP(commoner, version) {
     // variables is preferable to passing them as arguments.
     commoner.preferredFileExtension = pfe;
     commoner.watch = options.watch;
-    commoner.ignoreDependencies = !options.followRequires;
+    commoner.followRequires = options.followRequires;
     commoner.relativize = options.relativize;
     commoner.useProvidesModule = options.useProvidesModule;
     commoner.sourceCharset = normalizeCharset(options.sourceCharset);
@@ -258,8 +258,8 @@ function cliBuildP(commoner, version) {
         roots = ["<stdin>"];
         commoner.forceResolve("<stdin>", util.readFromStdinP());
 
-        // Ignore dependencies because we wouldn't know how to find them.
-        commoner.ignoreDependencies = true;
+        // Don't follow requires because we wouldn't know how to find them.
+        commoner.followRequires = false;
 
     } else {
         var first = absolutePath(workingDir, args[0]);
@@ -275,8 +275,8 @@ function cliBuildP(commoner, version) {
                 util.readFileP(first, commoner.sourceCharset)
             );
 
-            // Ignore dependencies because we wouldn't know how to find them.
-            commoner.ignoreDependencies = true;
+            // Don't follow requires because we wouldn't know how to find them.
+            commoner.followRequires = false;
 
         } else if (stats.isDirectory(first)) {
             sourceDir = first;

--- a/lib/commoner.js
+++ b/lib/commoner.js
@@ -3,6 +3,7 @@ var path = require("path");
 var fs = require("fs");
 var Q = require("q");
 var iconv = require("iconv-lite");
+var findup = require('findup-sync');
 var ReadFileCache = require("./cache").ReadFileCache;
 var Watcher = require("./watcher").Watcher;
 var contextModule = require("./context");
@@ -136,6 +137,11 @@ Cp.buildP = function(options, roots) {
 
         context.setUseProvidesModule(self.useProvidesModule);
 
+        if (self.ignoreDependencies) {
+            var dependencies = Object.keys(require(findup("package.json")).dependencies);
+            self.ignorePatterns.push(new RegExp("^(" + dependencies.join('|') + ")(\\/|$)"));
+        }
+
         context.setIgnorePatterns(self.ignorePatterns);
 
         return new ModuleReader(
@@ -225,6 +231,7 @@ function cliBuildP(commoner, version) {
                 "File extension to assume when resolving module identifiers")
         .option("--relativize", "Rewrite all module identifiers to be relative")
         .option("--follow-requires", "Scan modules for required dependencies")
+        .option("--ignore-dependencies", "Ignore modules defined as dependencies in package.json")
         .option("--use-provides-module", "Respect @providesModules pragma in files")
         .option("--cache-dir <directory>", "Alternate directory to use for disk cache")
         .option("--no-cache-dir", "Disable the disk cache")
@@ -246,6 +253,7 @@ function cliBuildP(commoner, version) {
     commoner.preferredFileExtension = pfe;
     commoner.watch = options.watch;
     commoner.followRequires = options.followRequires;
+    commoner.ignoreDependencies = options.ignoreDependencies;
     commoner.relativize = options.relativize;
     commoner.useProvidesModule = options.useProvidesModule;
     commoner.sourceCharset = normalizeCharset(options.sourceCharset);

--- a/lib/commoner.js
+++ b/lib/commoner.js
@@ -27,6 +27,7 @@ function Commoner() {
     Object.defineProperties(self, {
         customVersion: { value: null, writable: true },
         customOptions: { value: [] },
+        ignorePatterns: { value: [] },
         resolvers: { value: [] },
         processors: { value: [] }
     });
@@ -64,6 +65,16 @@ Cp.process = function(processor) {
     each.call(arguments, function(processor) {
         assert.strictEqual(typeof processor, "function");
         this.processors.push(processor);
+    }, this);
+
+    return this; // For chaining.
+};
+
+// Specify specific id patterns that should be ignored and not processed
+Cp.ignore = function() {
+    each.call(arguments, function(pattern) {
+        assert.ok(pattern instanceof RegExp, "ignore pattern must be a regular expression");
+        this.ignorePatterns.push(pattern);
     }, this);
 
     return this; // For chaining.
@@ -124,6 +135,8 @@ Cp.buildP = function(options, roots) {
         context.setRelativize(self.relativize);
 
         context.setUseProvidesModule(self.useProvidesModule);
+
+        context.setIgnorePatterns(self.ignorePatterns);
 
         return new ModuleReader(
             context,

--- a/lib/context.js
+++ b/lib/context.js
@@ -109,6 +109,15 @@ BCp.setUseProvidesModule = function(value) {
 // This default can be overridden by individual BuildContext instances.
 BCp.setUseProvidesModule(false);
 
+BCp.setIgnorePatterns = function(ignorePatterns) {
+    Object.defineProperty(this, "ignorePatterns", {
+        value: ignorePatterns || []
+    });
+};
+
+// This default can be overridden by individual BuildContext instances.
+BCp.setIgnorePatterns([]);
+
 BCp.setCacheDirectory = function(dir) {
     if (!dir) {
         // Disable the cache directory.

--- a/lib/context.js
+++ b/lib/context.js
@@ -82,14 +82,14 @@ BCp.spawnP = function(command, args, kwargs) {
     return deferred.promise;
 };
 
-BCp.setIgnoreDependencies = function(value) {
-    Object.defineProperty(this, "ignoreDependencies", {
+BCp.setFollowRequires = function(value) {
+    Object.defineProperty(this, "followRequires", {
         value: !!value
     });
 };
 
 // This default can be overridden by individual BuildContext instances.
-BCp.setIgnoreDependencies(false);
+BCp.setFollowRequires(true);
 
 BCp.setRelativize = function(value) {
     Object.defineProperty(this, "relativize", {

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -221,7 +221,6 @@ ModuleReader.prototype = {
             if (ids.length === 0)
                 return ids; // Shortcut.
 
-
             if (ignorePatterns.length) {
                 ids = ids.filter(function(id) {
                     for (var i = 0; i < ignorePatterns.length; i++) {

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -34,7 +34,7 @@ function ModuleReader(context, resolvers, processors) {
     resolvers = hashCallbacks("resolvers", resolvers, warnMissingModule);
 
     var procArgs = [processors];
-    if (context.relativize && !context.ignoreDependencies)
+    if (context.relativize && context.followRequires)
         procArgs.push(require("./relative").getProcessor(self));
     processors = hashCallbacks("processors", procArgs);
 

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -215,10 +215,23 @@ ModuleReader.prototype = {
 
     readMultiP: function(ids) {
         var reader = this;
+        var ignorePatterns = reader.context.ignorePatterns;
 
         return Q(ids).all().then(function(ids) {
             if (ids.length === 0)
                 return ids; // Shortcut.
+
+            if (ignorePatterns.length) {
+                ids = ids.filter(function(id) {
+                    for (var i = 0; i < ignorePatterns.length; i++) {
+                        if (ignorePatterns[i].test(id)) {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                });
+            }
 
             var modulePs = ids.map(reader.readModuleP, reader);
             return Q(modulePs).all().then(function(modules) {

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -221,6 +221,7 @@ ModuleReader.prototype = {
             if (ids.length === 0)
                 return ids; // Shortcut.
 
+
             if (ignorePatterns.length) {
                 ids = ids.filter(function(id) {
                     for (var i = 0; i < ignorePatterns.length; i++) {

--- a/lib/relative.js
+++ b/lib/relative.js
@@ -78,6 +78,14 @@ Rp.absolutizeP = function(moduleId, requiredId) {
 };
 
 Rp.relativizeP = function(moduleId, requiredId) {
+    var ignorePatterns = this.reader && this.reader.context.ignorePatterns || [];
+
+    for (var i = 0; i < ignorePatterns.length; i++) {
+        if (ignorePatterns[i].test(requiredId)) {
+            return Q(requiredId);
+        }
+    }
+
     return this.absolutizeP(
         moduleId,
         requiredId

--- a/lib/util.js
+++ b/lib/util.js
@@ -376,8 +376,10 @@ function makeIgnorePattern(modules) {
 exports.makeIgnorePattern = makeIgnorePattern;
 
 function makeDepsIgnorePattern() {
-    var deps = Object.keys(require(findup("package.json")).dependencies);
-    return makeIgnorePattern(deps);
+    var packageInfo = require(findup("package.json"));
+    var deps = Object.keys(packageInfo.dependencies || {});
+    var devDeps = Object.keys(packageInfo.devDependencies || {});
+    return makeIgnorePattern(deps.concat(devDeps));
 }
 exports.makeDepsIgnorePattern = makeDepsIgnorePattern;
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -5,6 +5,7 @@ var Q = require("q");
 var createHash = require("crypto").createHash;
 var mkdirp = require("mkdirp");
 var iconv = require("iconv-lite");
+var findup = require('findup-sync');
 var Ap = Array.prototype;
 var slice = Ap.slice;
 var join = Ap.join;
@@ -368,3 +369,19 @@ function camelize(hyphenated) {
     });
 }
 exports.camelize = camelize;
+
+function makeIgnorePattern(modules) {
+    return new RegExp("^(" + modules.join('|') + ")(\\/|$)");
+}
+exports.makeIgnorePattern = makeIgnorePattern;
+
+function makeDepsIgnorePattern() {
+    var deps = Object.keys(require(findup("package.json")).dependencies);
+    return makeIgnorePattern(deps);
+}
+exports.makeDepsIgnorePattern = makeDepsIgnorePattern;
+
+function makeCoreIgnorePattern() {
+    return makeIgnorePattern(require("repl")._builtinLibs);
+}
+exports.makeCoreIgnorePattern = makeCoreIgnorePattern;

--- a/main.js
+++ b/main.js
@@ -14,3 +14,4 @@ function defCallback(name) {
 defCallback("version");
 defCallback("resolve");
 defCallback("process");
+defCallback("ignore");

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "mkdirp": "~0.5.0",
     "private": "~0.1.6",
     "install": "~0.1.7",
-    "iconv-lite": "~0.4.5"
+    "iconv-lite": "~0.4.5",
+    "findup-sync": "~0.2.1"
   },
   "devDependencies": {
     "mocha": "~2.0.1"

--- a/test/run.js
+++ b/test/run.js
@@ -82,6 +82,7 @@ function checkHome(assert, home) {
         assert.notEqual(home.source.indexOf('require("react/addons");'), -1);
         assert.notEqual(home.source.indexOf('require("recast");'), -1);
         assert.notEqual(home.source.indexOf('require("recast/lib/types");'), -1);
+        assert.notEqual(home.source.indexOf('require("mocha");'), -1);
         assert.notEqual(home.source.indexOf('require("fs");'), -1);
         return home;
     }).invoke("getRequiredP").then(function(reqs) {

--- a/test/run.js
+++ b/test/run.js
@@ -29,6 +29,7 @@ function getNewContext(options) {
     context.setCacheDirectory(path.join(outputDir, options.cacheDirectory));
     context.setRelativize(options.relative === undefined || options.relative);
     context.setUseProvidesModule(options.useProvidesModule === undefined || options.useProvidesModule );
+    context.setIgnorePatterns(options.ignorePatterns || [ /ignored/, /^react[\/$]/ ]);
     return context;
 }
 
@@ -77,6 +78,8 @@ function checkHome(assert, home) {
         assert.strictEqual(typeof home.source, "string");
         assert.notEqual(home.source.indexOf("exports"), -1);
         assert.strictEqual(home.source.indexOf('require("./assert");'), 0);
+        assert.notEqual(home.source.indexOf('require("ignored-module");'), -1);
+        assert.notEqual(home.source.indexOf('require("react/addons");'), -1);
         return home;
     }).invoke("getRequiredP").then(function(reqs) {
         assert.strictEqual(reqs.length, 1);

--- a/test/run.js
+++ b/test/run.js
@@ -401,7 +401,7 @@ describe("canonical module identifiers", function() {
 
     it("should replace non-canonical required identifiers", function(done) {
         function helperP(context) {
-            assert.strictEqual(context.ignoreDependencies, false);
+            assert.strictEqual(context.followRequires, true);
 
             var reader = new ModuleReader(context, [
                 getProvidedP,

--- a/test/source/assert.js
+++ b/test/source/assert.js
@@ -1,7 +1,0 @@
-function assert(test, msg) {
-    if (!test) {
-        throw new Error(msg);
-    }
-}
-
-module.exports = assert.ok = assert;

--- a/test/source/home.js
+++ b/test/source/home.js
@@ -7,6 +7,7 @@ require("react/addons"); // also ignored
 
 require("recast"); // defined as dependency in package.json
 require("recast/lib/types");
+require("mocha"); // a dev dependency
 
 require("fs"); // node built-in
 

--- a/test/source/home.js
+++ b/test/source/home.js
@@ -5,4 +5,7 @@ require("./tests/../assert");
 require("ignored-module");
 require("react/addons"); // also ignored
 
+require("recast"); // defined as dependency in package.json
+require("recast/lib/types");
+
 exports.name = "home";

--- a/test/source/home.js
+++ b/test/source/home.js
@@ -1,11 +1,13 @@
-require("assert");
-require("./assert");
-require("./tests/../assert");
+require("myassert");
+require("./myassert");
+require("./tests/../myassert");
 
 require("ignored-module");
 require("react/addons"); // also ignored
 
 require("recast"); // defined as dependency in package.json
 require("recast/lib/types");
+
+require("fs"); // node built-in
 
 exports.name = "home";

--- a/test/source/home.js
+++ b/test/source/home.js
@@ -2,4 +2,7 @@ require("assert");
 require("./assert");
 require("./tests/../assert");
 
+require("ignored-module");
+require("react/addons"); // also ignored
+
 exports.name = "home";

--- a/test/source/myassert.js
+++ b/test/source/myassert.js
@@ -1,0 +1,7 @@
+function myassert(test, msg) {
+    if (!test) {
+        throw new Error(msg);
+    }
+}
+
+module.exports = myassert.ok = myassert;

--- a/test/source/widget/follow.js
+++ b/test/source/widget/follow.js
@@ -9,9 +9,9 @@ require("../WidgetShare");
 require("../widget/gallery");
 require("./gallery");
 
-// These both become "../assert".
-require("assert");
-require("../assert");
+// These both become "../myassert".
+require("myassert");
+require("../myassert");
 
 // These circular references should both become "./follow".
 require("./follow");


### PR DESCRIPTION
I've waited nearly 2 months for PR #75 to be finished. So here is my attempt on it.

This also fixes the relativize problem described in one of the comments of #75.

As an extra, this PR adds two new CLI flags:

```
--ignore-dependencies   Ignore required modules that are defined as dependencies in package.json
--ignore-node-core      Ignore required modules that are Node core modules ('fs', 'events', etc.)
```

Cherry-pick as much as your heart desires.
