### PR TITLE
Update recast version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "q": "~1.1.2",
-    "recast": "~0.9.5",
+    "recast": "~0.10.0",
     "commander": "~2.5.0",
     "graceful-fs": "~3.0.4",
     "glob": "~4.2.1",


### PR DESCRIPTION
@benjamn 

We are using `babel` and seems like the dependency tree will cause two version of the `recast` being download.

``` js
recast
------
0.10.12
-> babel -> babel-core -> regenerator -> recast
-> babel -> babel-core -> regexpu -> recast
0.9.18
-> babel -> babel-core -> regenerator -> commoner -> recast
```
