### PR TITLE
Update dependencies and devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,18 +29,18 @@
     "test": "rm -rf test/output ; node ./node_modules/mocha/bin/mocha --reporter spec test/run.js"
   },
   "dependencies": {
-    "q": "~1.1.2",
-    "recast": "~0.10.0",
-    "commander": "~2.5.0",
-    "graceful-fs": "~3.0.4",
-    "glob": "~4.2.1",
-    "mkdirp": "~0.5.0",
-    "private": "~0.1.6",
-    "install": "~0.1.7",
-    "iconv-lite": "~0.4.5"
+    "q": "^1.1.2",
+    "recast": "^0.10.0",
+    "commander": "^2.5.0",
+    "graceful-fs": "^4.1.2",
+    "glob": "^5.0.15",
+    "mkdirp": "^0.5.0",
+    "private": "^0.1.6",
+    "install": "^0.1.8",
+    "iconv-lite": "^0.4.5"
   },
   "devDependencies": {
-    "mocha": "~2.0.1"
+    "mocha": "^2.3.3"
   },
   "engines": {
     "node": ">= 0.8"


### PR DESCRIPTION
npm v3 tries to dedupe the dependencies by default, and keeping dependencies up-to-date helps better deduplication.

I could update almost all the dependencies _except for_ [`install` v0.2.6](https://github.com/benjamn/install/tree/v0.2.6), because its API seems different from the one documented on its [README](https://github.com/benjamn/install/tree/7dc68c0d65461c197a018c2a7a9d3ec6ac771ff7#usage).
