### PR TITLE
Reduce package size by adding `files` field to package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,11 @@
     "url": "git://github.com/reactjs/commoner.git"
   },
   "main": "main.js",
+  "files": [
+    "bin",
+    "lib",
+    "main.js"
+  ],
   "bin": {
     "commonize": "./bin/commonize"
   },


### PR DESCRIPTION
This change excludes `.gitignore`, `.travis.yml` and `test` directory from the npm package.

(No need to specify `README.md` and `LICENSE` since they are included by default. https://docs.npmjs.com/files/package.json#files)
